### PR TITLE
Find type if its missing in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@
 - #1 Support parameters defined for all the operations
 - #2 support `multipleOf` property
 - #3 Support for pattern
+- Use only alpha characters for the string mock
+- If `type` is missing try to find the type. default to `object`

--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -17,14 +17,14 @@ var Generators = module.exports = {
 function mock(schema) {
     var mock;
     if (schema) {
-        var type = schema.type || 'object'; // Use 'object' as the default type
+        var type = schema.type || findType(schema);
         var example = schema.examples || schema.example;
         /**
          * Use examples as Mock if provided
          */
         if (example) {
             mock = example;
-        } else if (type) {
+        } else {
             /**
              * Get the mock generator from the `type` of the schema
              */
@@ -165,7 +165,8 @@ function stringMock(schema) {
         mockStr = Format[schema.format].call(null, schema);
     } else {
         mockStr = Chance.string({
-            length: Chance.integer(opts)
+            length: Chance.integer(opts),
+            alpha: true //Use only alpha characters
         });
     }
 
@@ -183,4 +184,16 @@ function enumMock(schema) {
 
 function fileMock() {
     return Chance.file();
+}
+
+//Find out the type based on schema props
+//(This is not a complete list or full proof solution)
+function findType(schema) {
+    var type = 'object'// Use 'object' as the default type
+    if (schema.enum || schema.pattern) {
+        type = 'string';
+    } else if (schema.items) {
+        type = 'array';
+    }
+    return type;
 }


### PR DESCRIPTION
- Use only alpha characters for the string mock
- If `type` is missing try to find the type. default to `object`