### PR TITLE
fix arrayMock exceeds max allowed

### DIFF
--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -65,8 +65,8 @@ function objectMock(schema) {
  */
 function arrayMock(schema) {
     var items = schema.items;
-    var min = 0;
-    var max = 1;
+    var min = 1;
+    var max = 2;
     var arr = [];
 
     if (items) {
@@ -76,7 +76,7 @@ function arrayMock(schema) {
         if (schema.maxItems) {
             max = schema.maxItems;
         }
-        for (; min <= max; min++) {
+        for (; arr.length < max; min++) {
             arr.push(mock(items));
         }
     }


### PR DESCRIPTION
there's bug were arrayMock generates 1 item more than the specified in maxItems
this solves this problem.