### PR TITLE
Add support for an x-format property

### DIFF
--- a/lib/generators/format.js
+++ b/lib/generators/format.js
@@ -7,11 +7,13 @@ const date = () => Moment().format('YYYY-MM-DD');
 const dataTime = () => Moment().toISOString();
 const url = () => Chance.url();
 const email = () => Chance.email();
+const firstname = () =>Chance.first();
 const phone = () => Chance.phone();
 const guid = () => Chance.guid();
 const ipv4 = () => Chance.ip();
 const ipv6 = () => Chance.ipv6();
 const hostname = () => Randexp(/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/gm);
+const lastname = () => Chance.last();
 
 module.exports = {
     date,
@@ -20,6 +22,9 @@ module.exports = {
     url,
     email,
     phone,
+    firstname,
+    lastname,
+    'name': firstname,
     uuid: guid,
     guid,
     ipv4,

--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -183,6 +183,11 @@ const stringMock = schema => {
          * If a `format` is defined for the property
          */
         mockStr = Format[schema.format].call(null, schema);
+   } else if (Format[schema['x-format']]) {
+        /**
+         * If an `x-format` is defined for the property
+         */
+        mockStr = Format[schema['x-format']].call(null, schema);
     } else {
         mockStr = Chance.string({
             length: Chance.integer(opts),


### PR DESCRIPTION
As chance.js is being used, the scope of the type of data that can be mocked is more than the "common" formats used informally by the swagger spec. 

Rather than confuse this, I've used an extension to the property as `x-format` which can be used to provide format hinting.

For the moment this is limited to `firstname` and `lastname` which does the appropriate mapping to chance.js however this could be extended to deal with things like place data etc to comprise the wider set of data chance.js can create.

example property definition: 

``` yaml

  person:
    type: object
    properties:
      id:
        type: string
        format: uuid
        description: UUIDv4 for the specific person
      email:
        type: string
        format: email
        description: email address for the person
      phone:
        type: string
        format: phone
      first_name:
        type: string
        x-format: firstname
        description: Name of the person
      last_name:
        type: string
        x-format: lastname
```
