### PR TITLE
per swagger spec, parameter is header, not headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,10 +199,10 @@ const mockRequest = (resolved, parameters) => {
             mock.body = parameters.body[0].value;
         }
         //headers
-        if (parameters.headers && parameters.headers.length > 0) {
+        if (parameters.header && parameters.header.length > 0) {
             //Assuming only one Body for a request.
-            headerObj = parameters.headers.reduce(function (aggr, headersParam) {
-                aggr[headersParam.name] = headersParam.value;
+            headerObj = parameters.header.reduce(function (aggr, headerParam) {
+                aggr[headerParam.name] = headerParam.value;
                 return aggr;
             }, headerObj);
             // `consumes` property


### PR DESCRIPTION
I believe, per the swagger 2.0 spec, the parameter type for headers is just `header`(<https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject>).  Let me  know. Thanks.

Richard