### PR TITLE
Respect allOf when generating mocked responses.

### DIFF
--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -23,7 +23,7 @@ const mock = (schema, useExample)  => {
     return mock;
 };
 
-const objectMock = ({ properties, additionalProperties }, useExample ) => {
+const objectMock = ({ properties, additionalProperties, allOf }, useExample ) => {
     let mockObj = {};
     if (properties) {
         Object.keys(properties).forEach(function (key) {
@@ -40,6 +40,17 @@ const objectMock = ({ properties, additionalProperties }, useExample ) => {
         //Create a random property
         mockObj[Chance.word()] = mock(additionalProperties, useExample);
     }
+
+    /**
+     * Check if `allOf` is defined. If so, iterate through all of the objects mentioned
+     * in the array and merge them with this result.
+     */
+    if (allOf) {
+        allOf.forEach((subObject) => {
+            Object.assign(mockObj, mock(subObject, useExample));
+        });
+    }
+
     return mockObj;
 };
 /**

--- a/tests/fixture/petstore.json
+++ b/tests/fixture/petstore.json
@@ -806,6 +806,27 @@
         "Pet": {
             "type": "object",
             "required": ["name", "photoUrls"],
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "test-one": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "test-two": {
+                            "type": "integer",
+                            "format": "int64",
+                            "example": 20
+                        }
+                    }
+                }
+            ],
             "properties": {
                 "id": {
                     "type": "integer",

--- a/tests/response_mockgen.js
+++ b/tests/response_mockgen.js
@@ -78,6 +78,21 @@ describe('Response Mock generator', () => {
         });
     });
 
+    it('should include properties specified in allOf for path /pet/{petId}', (done) => {
+      swagmock.responses({
+          path: '/pet/{petId}',
+          operation: 'get',
+          response: '200',
+          useExamples: true
+      }, (err, mock) => {
+          let resp = mock.responses;
+          Assert.ok(resp['test-one'], 'Generated value for test-one');
+          Assert.equal(resp['test-two'], 20);
+          Assert.ok(resp['name'], 'Generated value for name');
+          done();
+      });
+    });
+
     it('should generate response mock for path /pet/{petId}/uploadImage', (done) => {
         swagmock.responses({
             path: '/pet/{petId}/uploadImage',


### PR DESCRIPTION
In my usage of this library, I'll run into something similar to the following schema:

```json
{
    "type": "object",
    "required": ["name", "photoUrls"],
    "allOf": [
        {
            "type": "object",
            "properties": {
                "test-one": {
                    "type": "integer",
                    "format": "int64"
                }
            }
        },
        {
            "type": "object",
            "properties": {
                "test-two": {
                    "type": "integer",
                    "format": "int64",
                    "example": 20
                }
            }
        }
    ],
    "properties": {
        "id": {
            "type": "integer",
            "format": "int64"
        },
        "category": {
            "$ref": "#/definitions/Category"
        },
        "name": {
            "type": "string",
            "example": "doggie"
        },
        "photoUrls": {
            "type": "array",
            "xml": {
                "name": "photoUrl",
                "wrapped": true
            },
            "items": {
                "type": "string"
            }
        },
        "tags": {
            "type": "array",
            "minItems": 2,
            "maxItems": 5,
            "xml": {
                "name": "tag",
                "wrapped": true
            },
            "items": {
                "$ref": "#/definitions/Tag"
            }
        },
        "status": {
            "type": "string",
            "description": "pet status in the store",
            "enum": ["available", "pending", "sold"]
        }
    },
    "xml": {
        "name": "Pet"
    }
}
```

Currently, the library doesn't generate values for `test-one` or `test-two` since they're hidden inside the `allOf` clause of the schema. This PR updates the response mocker to respect the `allOf` clause and generate values for it as well.