### PR TITLE
Make the example check a bit stricter.

### DIFF
--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -11,7 +11,7 @@ const mock = (schema, useExample)  => {
         /**
          * Get the mock generator from the `type` of the schema
          */
-        if (example && useExample) {
+        if (typeof example !== 'undefined' && useExample) {
             mock = example;
         } else {
             const generator = Generators[type];

--- a/tests/fixture/petstore.json
+++ b/tests/fixture/petstore.json
@@ -844,6 +844,11 @@
                     "type": "string",
                     "description": "pet status in the store",
                     "enum": ["available", "pending", "sold"]
+                },
+                "mean": {
+                    "type": "boolean",
+                    "description": "whether or not the pet is mean",
+                    "example": false
                 }
             },
             "xml": {

--- a/tests/response_mockgen.js
+++ b/tests/response_mockgen.js
@@ -78,6 +78,19 @@ describe('Response Mock generator', () => {
         });
     });
 
+    it('should use the example false when generating with examples for path /pet/{petId}', (done) => {
+        swagmock.responses({
+            path: '/pet/{petId}',
+            operation: 'get',
+            response: '200',
+            useExamples: true
+        }, (err, mock) => {
+            let resp = mock.responses;
+            Assert.equal(resp.mean, false);
+            done();
+        });
+    });
+
     it('should generate response mock for path /pet/{petId}/uploadImage', (done) => {
         swagmock.responses({
             path: '/pet/{petId}/uploadImage',


### PR DESCRIPTION
Connected to https://github.com/subeeshcbabu/swagmock/pull/44. Duplicate of https://github.com/subeeshcbabu/swagmock/pull/48 (had to rename the branch).

Implemented this so the examples support boolean `false` as the example value instead of generating a random boolean.