### PR TITLE
Add support for integer formats int32 and int64

### DIFF
--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -90,6 +90,12 @@ const integerMock = schema => {
         return enumMock(schema);
     }
 
+    // Limit range for int32 format - it can still be overwritten by explicit range declaration
+    if (schema.format === 'int32') {
+        opts.min = -2147483648;
+        opts.max = 2147483647;
+    }
+
     if (Number.isInteger(schema.minimum)) {
         opts.min = (schema.exclusiveMinimum) ? schema.minimum + 1 : schema.minimum;
     }

--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -95,6 +95,12 @@ const integerMock = schema => {
         opts.min = -2147483648;
         opts.max = 2147483647;
     }
+    else if (schema.format === 'int64') {
+        // Note: We cannot use 9223372036854775807 and -9223372036854775808 range,
+        // they are rounded by JS and therefore unsafe to be used
+        opts.max = Number.MIN_SAFE_INTEGER;
+        opts.max = Number.MAX_SAFE_INTEGER;
+    }
 
     if (Number.isInteger(schema.minimum)) {
         opts.min = (schema.exclusiveMinimum) ? schema.minimum + 1 : schema.minimum;

--- a/tests/request_mockgen.js
+++ b/tests/request_mockgen.js
@@ -89,6 +89,7 @@ describe('Request Mock generator', () => {
             let order = request.body;
             Assert.ok(typeof order === 'object', 'OK value for body');
             Assert.ok(Number.isInteger(order.id), 'order.id is integer');
+            Assert.ok(order.id >= -9223372036854775000 && order.id <= 9223372036854775000, 'id has value in int64 range');
             Assert.ok(Number.isInteger(order.petId), 'order.petId is integer');
             Assert.ok(Number.isInteger(order.quantity), 'order.quantity is integer');
             Assert.ok(typeof order.shipDate === 'string', 'order.shipDate is string');

--- a/tests/response_mockgen.js
+++ b/tests/response_mockgen.js
@@ -89,6 +89,8 @@ describe('Response Mock generator', () => {
             Assert.ok(mock, 'Generated mock');
             let resp = mock.responses;
             Assert.ok(resp, 'Generated response');
+            Assert.ok(Number.isInteger(resp.code), 'response.code is integer');
+            Assert.ok(resp.code >= -2147483648 && resp.code <= 2147483647, 'response.code is has value in int32 range');
             //TODO add asserts for pending props
             done();
         });

--- a/tests/response_mockgen.js
+++ b/tests/response_mockgen.js
@@ -90,7 +90,7 @@ describe('Response Mock generator', () => {
             let resp = mock.responses;
             Assert.ok(resp, 'Generated response');
             Assert.ok(Number.isInteger(resp.code), 'response.code is integer');
-            Assert.ok(resp.code >= -2147483648 && resp.code <= 2147483647, 'response.code is has value in int32 range');
+            Assert.ok(resp.code >= -2147483648 && resp.code <= 2147483647, 'response.code ' + resp.code + ' has value in int32 range');
             //TODO add asserts for pending props
             done();
         });

--- a/tests/responses_mockgen.js
+++ b/tests/responses_mockgen.js
@@ -22,6 +22,7 @@ describe('Responses Mock generator', () => {
             Assert.ok(resp.hasOwnProperty('404'), 'Generated 404 response');
             let successResp = resp['200'];
             Assert.ok(Number.isInteger(successResp.id), 'id is integer');
+            Assert.ok(successResp.id >= -9223372036854775000 && successResp.id <= 9223372036854775000, 'id has value in int64 range');
             Assert.ok(Number.isInteger(successResp.petId), 'petId is integer');
             Assert.ok(Number.isInteger(successResp.quantity), 'quantity is integer');
             Assert.ok(typeof successResp.shipDate === 'string', 'shipDate is string');
@@ -50,6 +51,7 @@ describe('Responses Mock generator', () => {
             let pet = resp[0];
             Assert.ok(pet, 'Ok Pet response');
             Assert.ok(Number.isInteger(pet.id), 'id is integer');
+            Assert.ok(pet.id >= -9223372036854775000 && pet.id <= 9223372036854775000, 'id has value in int64 range');
             done();
         }).catch(err => {
             Assert.ok(!err, 'No error');


### PR DESCRIPTION
Limit range of generated numbers for these integer subtypes.

They are well known by OpenAPI: https://swagger.io/docs/specification/data-models/data-types/#numbers

Note Number has larger absolute range than int64, but numbers outside MAX_SAFE_INTEGER and MIN_SAFE_INTEGER range are rounded. To avoid wierd behavior, I've set limits for int64 to these SAFE constraints.

I've added asserts to tests, but since numbers are random-generated, they are not really conclusive.. I've ran tests 100 times to make sure its likely correct.